### PR TITLE
(test jules) Handle AttributeError for ollama client 'embed' method

### DIFF
--- a/hugegraph-llm/src/hugegraph_llm/models/embeddings/ollama.py
+++ b/hugegraph-llm/src/hugegraph_llm/models/embeddings/ollama.py
@@ -39,8 +39,41 @@ class OllamaEmbedding(BaseEmbedding):
             self,
             text: str
     ) -> List[float]:
-        """Comment"""
-        return list(self.client.embed(model=self.model, input=text)["embeddings"][0])
+        """Get embedding for a single text.
+
+        This method handles different Ollama client API versions by checking for
+        the presence of 'embed' or 'embeddings' methods.
+        """
+        if hasattr(self.client, "embed"):
+            response = self.client.embed(model=self.model, input=text)
+            try:
+                # First, try the structure typically seen for single embeddings
+                # or newer batch responses that might return a single "embedding" key.
+                return list(response["embedding"])
+            except KeyError:
+                # Fallback for older batch-like response for single item,
+                # or if "embeddings" is a list with one item.
+                try:
+                    return list(response["embeddings"][0])
+                except (KeyError, IndexError) as e:
+                    raise RuntimeError(
+                        "Failed to extract embedding from Ollama client 'embed' response. "
+                        f"Response: {response}. Error: {e}"
+                    )
+        elif hasattr(self.client, "embeddings"):
+            response = self.client.embeddings(model=self.model, prompt=text)
+            try:
+                return list(response["embedding"])
+            except KeyError as e:
+                raise RuntimeError(
+                    "Failed to extract embedding from Ollama client 'embeddings' response. "
+                    f"Response: {response}. Error: {e}"
+                )
+        else:
+            raise AttributeError(
+                "Ollama client object has neither 'embed' nor 'embeddings' method. "
+                "Please check your ollama library version."
+            )
 
     def get_texts_embeddings(
             self,
@@ -63,8 +96,20 @@ class OllamaEmbedding(BaseEmbedding):
             A list of embedding vectors, where each vector is a list of floats.
             The order of embeddings matches the order of input texts.
         """
-        response = self.client.embed(model=self.model, input=texts)["embeddings"]
-        return [list(inner_sequence) for inner_sequence in response]
+        if hasattr(self.client, "embed"):
+            response = self.client.embed(model=self.model, input=texts)["embeddings"]
+            return [list(inner_sequence) for inner_sequence in response]
+        elif hasattr(self.client, "embeddings"):
+            embeddings_list = []
+            for text_item in texts:
+                response_item = self.client.embeddings(model=self.model, prompt=text_item)
+                embeddings_list.append(list(response_item["embedding"]))
+            return embeddings_list
+        else:
+            raise AttributeError(
+                "Ollama client object has neither 'embed' nor 'embeddings' method. "
+                "Please check your ollama library version."
+            )
 
     async def async_get_text_embedding(
             self,


### PR DESCRIPTION
The 'Client' object from the ollama library was reported to not have an 'embed' attribute in some of your environments, leading to an AttributeError. This issue can arise from mismatches between the ollama version specified in requirements.txt and the version active in the execution environment.

This commit introduces fallback logic in the `OllamaEmbedding` class methods:
- `get_texts_embeddings`:
  - Now first attempts to use `self.client.embed()`.
  - If `embed` is not found, it falls back to the deprecated `self.client.embeddings()`. Since `embeddings` typically handles single prompts, this fallback involves iterating through the batch of texts and calling the method for each.
  - Raises an AttributeError if neither method is found.
- `get_text_embedding`:
  - Similarly attempts `self.client.embed()` first. Response parsing is made more robust by trying `response["embedding"]` and then `response["embeddings"][0]` to handle different possible response structures for single inputs.
  - Falls back to `self.client.embeddings()` if `embed` is not found, using `response["embedding"]`.
  - Raises an AttributeError if neither method is found.

These changes aim to improve compatibility with different ollama library versions and provide a more resilient embedding generation process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 兼容不同版本的 Ollama 客户端 API，自动适配多种接口方式。
- **优化**
  - 增强了异常处理，遇到不支持的接口或异常响应时会提供更清晰的错误提示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->