### PR TITLE
support uv for hg-python-client

### DIFF
--- a/hugegraph-llm/README.md
+++ b/hugegraph-llm/README.md
@@ -23,12 +23,8 @@ graph systems and large language models.
 
 ## 3. Preparation
 
-1. Start the HugeGraph database, you can run it via [Docker](https://hub.docker.com/r/hugegraph/hugegraph)/[Binary Package](https://hugegraph.apache.org/docs/download/download/).
-    There is a simple method by docker:  
-    ```bash
-   docker run -itd --name=server -p 8080:8080 hugegraph/hugegraph
-    ```  
-   You can refer to the detailed documents [doc](https://hugegraph.apache.org/docs/quickstart/hugegraph-server/#31-use-docker-container-convenient-for-testdev) for more guidance.
+1. Start the HugeGraph database, you can run it via [Docker](https://hub.docker.com/r/hugegraph/hugegraph)/[Binary Package](https://hugegraph.apache.org/docs/download/download/).  
+    Refer to the detailed [doc](https://hugegraph.apache.org/docs/quickstart/hugegraph-server/#31-use-docker-container-convenient-for-testdev) for more guidance
 
 2. Configuring the uv environment, Use the official installer to install uv, See the [uv documentation](https://docs.astral.sh/uv/configuration/installer/) for other installation methods   
     ```bash

--- a/hugegraph-llm/pyproject.toml
+++ b/hugegraph-llm/pyproject.toml
@@ -64,28 +64,24 @@ documentation = "https://hugegraph.apache.org/docs/quickstart/hugegraph-ai/"
 "Bug Tracker" = "https://github.com/apache/incubator-hugegraph-ai/issues"
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
 
-#If you want to modify the network configuration file of the project, then you can modify this part
-[[tool.uv.index]]
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-default = true
+[[tool.poetry.source]]
+name = "pypi"
+priority = "primary"
 
-[tool.hatch.build.targets.wheel]
-packages = ["src/hugegraph_llm"]
+[[tool.poetry.source]]
+name = "aliyun"
+url = "https://mirrors.aliyun.com/pypi/simple/"
+priority = "supplemental"
 
-[tool.hatch.build.targets.sdist]
-include = [
-    "src/hugegraph_llm",
-    "README.md",
-    "LICENSE",
-    "NOTICE",
-    "MANIFEST.in"
-]
+[[tool.poetry.source]]
+name = "tencent"
+url = "https://mirrors.cloud.tencent.com/pypi/simple/"
+priority = "supplemental"
 
-[tool.hatch.metadata]
-allow-direct-references = true
-
-[tool.uv.sources]
-hugegraph-python = { path = "../hugegraph-python-client/", editable = true }
+[[tool.poetry.source]]
+name = "tsinghua"
+url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/"
+priority = "supplemental"


### PR DESCRIPTION
support uv for hg-python-client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档**
  - 简化了 README 的准备部分，删除了 HugeGraph 数据库的 Docker 启动示例，改为直接链接官方文档。

- **杂项**
  - 构建系统从 Hatch 切换为 Poetry，更新了依赖和包源配置，增加了多个 PyPI 镜像源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->