### PR TITLE
Prepare project config for Text2Gremlin

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -82,6 +82,9 @@ header: # `header` section is configurations for source codes license header.
     - '**/poetry.lock'
     - '.github/**/*'
     - 'docker/**/*'
+    - '**/*.interp'
+    - '**/*.tokens'
+    - '**/*.csv'
 
   comment: on-failure
   # on what condition license-eye will comment on the pull request, `on-failure`, `always`, `never`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,9 @@ addopts = "--strict-markers --strict-config"
 [tool.ruff]
 line-length = 120
 target-version = "py310"
+extend-exclude = [
+    "text2gremlin/AST_Text2Gremlin/base/gremlin/*.py",
+]
 
 [tool.ruff.lint]
 # Select a broad set of rules for comprehensive checks.
@@ -188,6 +191,30 @@ ignore = [
 "tests/**/*.py" = ["T20"]
 "hugegraph-ml/src/hugegraph_ml/examples/**/*.py" = ["T20"]
 "hugegraph-python-client/src/pyhugegraph/structure/*.py" = ["N802"]
+"text2gremlin/AST_Text2Gremlin/base/*.py" = [
+    "N999", # Keep existing standalone module names such as GremlinBase.py.
+]
+"text2gremlin/AST_Text2Gremlin/analyze_syntax.py" = ["T20"]
+"text2gremlin/AST_Text2Gremlin/generate_corpus.py" = ["T20"]
+"text2gremlin/AST_Text2Gremlin/run_llm_pipeline.py" = ["T20"]
+"text2gremlin/AST_Text2Gremlin/base/GremlinBase.py" = ["T20"]
+"text2gremlin/AST_Text2Gremlin/base/GremlinTransVisitor.py" = [
+    "F403", # ANTLR visitor compatibility import style.
+    "F811", # Visitor methods mirror grammar alternatives and may intentionally repeat names.
+    "T20",  # Parser diagnostics are printed by the standalone visitor helper.
+]
+"text2gremlin/AST_Text2Gremlin/base/TraversalGenerator.py" = [
+    "E501",   # Long generated traversal fragments are kept readable.
+    "E741",   # Gremlin examples may use compact variable names in local comprehensions.
+    "RUF012", # Class-level step configuration dictionaries are constants in practice.
+    "SIM102", # Keep complex traversal-generation branching explicit.
+    "SIM108", # Keep complex traversal-generation branching explicit.
+]
+"text2gremlin/AST_Text2Gremlin/llm_augment/*.py" = [
+    "E501",   # Long prompts are kept readable.
+    "RUF002", # Chinese prompt text intentionally uses full-width punctuation.
+    "T20",    # Standalone data-generation scripts write progress to stdout.
+]
 
 [tool.ruff.lint.isort]
 known-first-party = ["hugegraph_llm", "hugegraph_python_client", "hugegraph_ml", "vermeer_python_client"]

--- a/text2gremlin/AST_Text2Gremlin/.gitignore
+++ b/text2gremlin/AST_Text2Gremlin/.gitignore
@@ -1,0 +1,13 @@
+# 配置文件
+config.json
+.env
+output/
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg-info/
+.eggs/

--- a/text2gremlin/AST_Text2Gremlin/requirements.txt
+++ b/text2gremlin/AST_Text2Gremlin/requirements.txt
@@ -1,5 +1,5 @@
 antlr4-python3-runtime==4.13.1
-openai>=1.30.0
-pandas>=2.0.0
-pydantic>=2.0.0
-pytest>=8.0.0
+openai~=1.61.0
+pandas~=2.2.3
+pydantic~=2.10.6
+pytest~=8.0.0

--- a/text2gremlin/AST_Text2Gremlin/requirements.txt
+++ b/text2gremlin/AST_Text2Gremlin/requirements.txt
@@ -1,0 +1,5 @@
+antlr4-python3-runtime==4.13.1
+openai>=1.30.0
+pandas>=2.0.0
+pydantic>=2.0.0
+pytest>=8.0.0


### PR DESCRIPTION
This is the first split-out PR from the larger Text2Gremlin work in #52.

The full #52 PR is intentionally kept open for context while the work is submitted in smaller, reviewable parts. The original PR was too large to review safely as a single change, so this series will separate project plumbing, parser artifacts, AST generalization, demo data/templates, CLI/docs, LLM augmentation, DPO generation, and follow-up quality fixes.

This PR contains only the project plumbing needed before the implementation PRs:

- Add Text2Gremlin dependency requirements.
- Add local ignore rules for generated/output files.
- Add license exclusions for generated ANTLR metadata and CSV data files.
- Add narrowed Ruff configuration for the upcoming Text2Gremlin files.

It intentionally does not include parser code, AST/generalization logic, movie demo data, CLI/docs, LLM pipeline code, or DPO generation. Those will be submitted as follow-up PRs in smaller layers.

Validation:

- `uv run python` TOML parse check for `pyproject.toml`
- `uv run ruff format --check .`
- `uv run ruff check .`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 更新了代码检查与格式化规则，增加对特定自动生成/复杂文件的排除与按文件忽略，降低误报。
  * 扩展了许可证扫描的忽略范围，避免对特定文件类型进行覆盖处理。
  * 补充了项目忽略列表，防止环境文件、输出目录与构建产物被误纳入版本管理。
  * 新增并锁定运行所需依赖版本，完善依赖清单。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->